### PR TITLE
Feature: Preventing Rest based on ActiveEffect

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -508,6 +508,10 @@
           "Hint": "Here you can configure what a Verdan's Black Blood Healing feature is called in your game. This can be a localized string."
         }
       }
+    },
+    "Warnings": {
+      "PreventedLongRest" : "You cannot long rest because you are under an effect that prevents you from doing so!",
+      "PreventedShortRest" :  "You cannot short rest because you are under an effect that prevents you from doing so!"
     }
   }
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -87,7 +87,9 @@
       "ExhaustionArmor": "They chose to keep their armor on, and recovered none of their exhaustion.",
       "HitDiceArmor": "They recovered less hit dice than normal because they rested in their armor.",
       "NoHitDiceArmor": "They recovered none of their hit dice because they rested in their armor.",
-      "HitDiceNoArmor": "They chose to not rest in their armor, and regained the normal amount of hit dice."
+      "HitDiceNoArmor": "They chose to not rest in their armor, and regained the normal amount of hit dice.",
+      "CouldNotLongRest": " could not take a long rest.",
+      "CouldNotShortRest": " could not take a short rest."
     },
     "Dialogs": {
       "SaveProfile": {

--- a/languages/en.json
+++ b/languages/en.json
@@ -88,8 +88,8 @@
       "HitDiceArmor": "They recovered less hit dice than normal because they rested in their armor.",
       "NoHitDiceArmor": "They recovered none of their hit dice because they rested in their armor.",
       "HitDiceNoArmor": "They chose to not rest in their armor, and regained the normal amount of hit dice.",
-      "CouldNotLongRest": " could not take a long rest.",
-      "CouldNotShortRest": " could not take a short rest."
+      "CouldNotLongRest": "{actorName} could not take a long rest.",
+      "CouldNotShortRest": "{actorName} could not take a short rest."
     },
     "Dialogs": {
       "SaveProfile": {

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -88,8 +88,8 @@
       "HitDiceArmor": "They recovered less hit dice than normal because they rested in their armor.",
       "NoHitDiceArmor": "They recovered none of their hit dice because they rested in their armor.",
       "HitDiceNoArmor": "They chose to not rest in their armor, and regained the normal amount of hit dice.",
-      "CouldNotLongRest": " could not take a long rest.",
-      "CouldNotShortRest": " could not take a short rest."
+      "CouldNotLongRest": "{actorName} could not take a long rest.",
+      "CouldNotShortRest": "{actorName} could not take a short rest."
 
       "Dialogs": {
         "SaveProfile": {

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -83,7 +83,13 @@
       "WaterNoneNone": "N'a pas bu de la journée.",
       "NoExhaustion": "Mais a évité l'épuisement.",
       "Exhaustion": "Et souffre de {exhaustion} niveau d'épuisement.",
-      "ExhaustionDeath": "Malheureusement, {actorName} a péri en atteignant le niveau 6 d'épuisement."
+      "ExhaustionDeath": "Malheureusement, {actorName} a péri en atteignant le niveau 6 d'épuisement.",
+      "ExhaustionArmor": "They chose to keep their armor on, and recovered none of their exhaustion.",
+      "HitDiceArmor": "They recovered less hit dice than normal because they rested in their armor.",
+      "NoHitDiceArmor": "They recovered none of their hit dice because they rested in their armor.",
+      "HitDiceNoArmor": "They chose to not rest in their armor, and regained the normal amount of hit dice.",
+      "CouldNotLongRest": " could not take a long rest.",
+      "CouldNotShortRest": " could not take a short rest."
 
       "Dialogs": {
         "SaveProfile": {

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -90,7 +90,7 @@
       "HitDiceNoArmor": "They chose to not rest in their armor, and regained the normal amount of hit dice.",
       "CouldNotLongRest": "{actorName} could not take a long rest.",
       "CouldNotShortRest": "{actorName} could not take a short rest."
-
+    },
       "Dialogs": {
         "SaveProfile": {
           "Title": "Créer un profil",
@@ -426,6 +426,10 @@
             "Hint": "Vous pouvez configurer ici le nom capacité Récupération des sangs-noirs (verdan) dans votre partie. Il peut s'agir d'une chaîne localisée."
           }
         }
+      },
+      "Warnings": {
+        "PreventedLongRest" : "You cannot long rest because you are under an effect that prevents you from doing so!",
+        "PreventedShortRest" :  "You cannot short rest because you are under an effect that prevents you from doing so!"
       }
     }
   }

--- a/languages/pt_BR.json
+++ b/languages/pt_BR.json
@@ -88,8 +88,8 @@
         "HitDiceArmor": "Ele(a) recuperou menos dados de vida que o normal porque descansou vestindo sua armadura.",
         "NoHitDiceArmor": "Ele(a) não recuperou nenhum dado de vida porque descansou vestindo sua armadura.",
         "HitDiceNoArmor": "Ele(a) decidiu não vestir a sua armadura enquanto descansa e recuperou a quantidade normal de dados de vida.",
-        "CouldNotLongRest": " could not take a long rest.",
-        "CouldNotShortRest": " could not take a short rest."  
+        "CouldNotLongRest": "{actorName} could not take a long rest.",
+        "CouldNotShortRest": "{actorName} could not take a short rest."  
       },
       "Dialogs": {
         "SaveProfile": {

--- a/languages/pt_BR.json
+++ b/languages/pt_BR.json
@@ -456,6 +456,10 @@
             "Hint": "Aqui você pode configurar como o recurso Cura do Sangue Negro de um Verdan é chamado em seu jogo. Isso pode ser uma string localizada."
           }
         }
+      },
+      "Warnings": {
+        "PreventedLongRest" : "You cannot long rest because you are under an effect that prevents you from doing so!",
+        "PreventedShortRest" :  "You cannot short rest because you are under an effect that prevents you from doing so!"
       }
     }
 }

--- a/languages/pt_BR.json
+++ b/languages/pt_BR.json
@@ -87,7 +87,9 @@
         "ExhaustionArmor": "Ele(a) decidiu continuar vestindo sua armadura, e não recuperou nenhum dos seus pontos de exaustão.",
         "HitDiceArmor": "Ele(a) recuperou menos dados de vida que o normal porque descansou vestindo sua armadura.",
         "NoHitDiceArmor": "Ele(a) não recuperou nenhum dado de vida porque descansou vestindo sua armadura.",
-        "HitDiceNoArmor": "Ele(a) decidiu não vestir a sua armadura enquanto descansa e recuperou a quantidade normal de dados de vida."
+        "HitDiceNoArmor": "Ele(a) decidiu não vestir a sua armadura enquanto descansa e recuperou a quantidade normal de dados de vida.",
+        "CouldNotLongRest": " could not take a long rest.",
+        "CouldNotShortRest": " could not take a short rest."  
       },
       "Dialogs": {
         "SaveProfile": {

--- a/scripts/formapplications/prompt-rest/prompt-rest-shell.svelte
+++ b/scripts/formapplications/prompt-rest/prompt-rest-shell.svelte
@@ -87,10 +87,27 @@
     const timeChanges = lib.getTimeChanges(restType === "longRest");
     await game.time.advance(timeChanges.restTime);
 
-    SocketHandler.emit(SocketHandler.PROMPT_REST, {
-      userActors: [...configuration],
-      restType
-    })
+    let restText = (restType === "longRest") ? game.i18n.format("REST-RECOVERY.Chat.CouldNotLongRest") : game.i18n.format("REST-RECOVERY.Chat.CouldNotShortRest");
+
+    configuration.forEach((element) => {
+      if (getProperty(game.actors.get(element.split("-")[1]), `flags.dae.RR5EPrevent${restType}`)) {
+          configuration.delete(element);
+          ChatMessage.create({
+            content: `<br>${game.actors.get(element.split("-")[1]).name} ${restText}`,
+            speaker: {
+                alias: game.actors.get(element.split("-")[1]).name
+              }
+          });
+      };
+    });
+
+    if (configuration.size) {
+      SocketHandler.emit(SocketHandler.PROMPT_REST, {
+       userActors: [...configuration],
+       restType
+     })
+    } 
+    
     application.options.resolve();
     application.close();
   }

--- a/scripts/formapplications/prompt-rest/prompt-rest-shell.svelte
+++ b/scripts/formapplications/prompt-rest/prompt-rest-shell.svelte
@@ -87,17 +87,15 @@
     const timeChanges = lib.getTimeChanges(restType === "longRest");
     await game.time.advance(timeChanges.restTime);
 
-    let restText = (restType === "longRest") ? game.i18n.format("REST-RECOVERY.Chat.CouldNotLongRest") : game.i18n.format("REST-RECOVERY.Chat.CouldNotShortRest");
-
     configuration.forEach((element) => {
-      if (getProperty(game.actors.get(element.split("-")[1]), `flags.dae.RR5EPrevent${restType}`)) {
-          configuration.delete(element);
-          ChatMessage.create({
-            content: `<br>${game.actors.get(element.split("-")[1]).name} ${restText}`,
+    if (getProperty(game.actors.get(element.split("-")[1]), `flags.dae.rest-recovery.prevent.${restType}`)) {
+        configuration.delete(element);
+        ChatMessage.create({
+            content: "<p>" + localize("REST-RECOVERY.Chat.CouldNot" + (restType === "longRest" ? "LongRest" : "ShortRest"), {actorName: game.actors.get(element.split("-")[1]).name}) + "</p>",
             speaker: {
                 alias: game.actors.get(element.split("-")[1]).name
-              }
-          });
+            }
+        });
       };
     });
 

--- a/scripts/libwrapper.js
+++ b/scripts/libwrapper.js
@@ -22,6 +22,16 @@ export default function registerLibwrappers() {
   
 }
 
+function preventRestChatMessage(restType, actor) {
+  ChatMessage.create({
+      content: "<p>" + localize("REST-RECOVERY.Chat.CouldNot" + (restType === "longRest" ? "LongRest" : "ShortRest"), {
+          actorName: actor.name
+      }) + "</p>",
+      speaker: {
+          alias: actor.name
+      }
+  });
+}
 
 function patch_shortRest() {
   libWrapper.ignore_conflicts(CONSTANTS.MODULE_NAME, ["dnd5e-helpers"], [
@@ -44,6 +54,7 @@ function patch_shortRest() {
        * @param {RestConfiguration} config  Configuration options for the rest.
        * @returns {boolean}                 Explicitly return `false` to prevent the rest from being started.
        */
+      if (getProperty(this, `flags.dae.rest-recovery.prevent.shortRest`)) return preventRestChatMessage("shortRest", this);
       if ( Hooks.call("dnd5e.preShortRest", this, config) === false ) return;
       
       RestWorkflow.make(this);
@@ -91,6 +102,7 @@ function patch_longRest() {
        * @param {RestConfiguration} config  Configuration options for the rest.
        * @returns {boolean}                 Explicitly return `false` to prevent the rest from being started.
        */
+      if (getProperty(this, `flags.dae.rest-recovery.prevent.longRest`)) return preventRestChatMessage("longRest", this);
       if ( Hooks.call("dnd5e.preLongRest", this, config) === false ) return;
       
       RestWorkflow.make(this, true);

--- a/scripts/libwrapper.js
+++ b/scripts/libwrapper.js
@@ -22,17 +22,6 @@ export default function registerLibwrappers() {
   
 }
 
-function preventRestChatMessage(restType, actor) {
-  ChatMessage.create({
-      content: "<p>" + localize("REST-RECOVERY.Chat.CouldNot" + (restType === "longRest" ? "LongRest" : "ShortRest"), {
-          actorName: actor.name
-      }) + "</p>",
-      speaker: {
-          alias: actor.name
-      }
-  });
-}
-
 function patch_shortRest() {
   libWrapper.ignore_conflicts(CONSTANTS.MODULE_NAME, ["dnd5e-helpers"], [
     "CONFIG.Actor.documentClass.prototype.shortRest"
@@ -54,7 +43,10 @@ function patch_shortRest() {
        * @param {RestConfiguration} config  Configuration options for the rest.
        * @returns {boolean}                 Explicitly return `false` to prevent the rest from being started.
        */
-      if (getProperty(this, `flags.dae.rest-recovery.prevent.shortRest`)) return preventRestChatMessage("shortRest", this);
+      if (getProperty(this, `flags.dae.rest-recovery.prevent.shortRest`)) {
+        ui.notifications.warn("Rest Recovery | " + game.i18n.localize("REST-RECOVERY.Warnings.PreventedShortRest"))
+        return false;
+      }
       if ( Hooks.call("dnd5e.preShortRest", this, config) === false ) return;
       
       RestWorkflow.make(this);
@@ -102,7 +94,10 @@ function patch_longRest() {
        * @param {RestConfiguration} config  Configuration options for the rest.
        * @returns {boolean}                 Explicitly return `false` to prevent the rest from being started.
        */
-      if (getProperty(this, `flags.dae.rest-recovery.prevent.longRest`)) return preventRestChatMessage("longRest", this);
+      if (getProperty(this, `flags.dae.rest-recovery.prevent.longRest`)) {
+        ui.notifications.warn("Rest Recovery | "  + game.i18n.localize("REST-RECOVERY.Warnings.PreventedLongRest"))
+        return false;
+      }
       if ( Hooks.call("dnd5e.preLongRest", this, config) === false ) return;
       
       RestWorkflow.make(this, true);


### PR DESCRIPTION
Enhancement for [Request] Resting based on condition [#101](https://github.com/fantasycalendar/FoundryVTT-RestRecovery/issues/101)

This modification requires [DAE ](https://foundryvtt.com/packages/dae)to be installed/enabled. It checks if the actor has an item which prevents rest via AE, that case it displays a chat message and prevents rent.

![ksnip_20221214-222244](https://user-images.githubusercontent.com/92884040/207717780-d03452c3-cf6e-45ce-863f-f1adfe39a216.png)
![ksnip_20221214-221423](https://user-images.githubusercontent.com/92884040/207717772-0b4617c7-631a-4394-af47-1af285b63a64.png)
![ksnip_20221214-222213](https://user-images.githubusercontent.com/92884040/207717777-69a6a286-887e-4838-8fe6-504899b85a89.png)

