### PR TITLE
New day fixes

### DIFF
--- a/scripts/formapplications/long-rest/long-rest-shell.svelte
+++ b/scripts/formapplications/long-rest/long-rest-shell.svelte
@@ -35,8 +35,8 @@
   $: application.reactive.headerButtonNoClose = startedLongRest;
 
   const simpleCalendarActive = lib.getSetting(CONSTANTS.SETTINGS.ENABLE_SIMPLE_CALENDAR_INTEGRATION);
-  const timeChanges = lib.getTimeChanges(false);
-  let newDay = simpleCalendarActive ? timeChanges.isNewDay : application.options.newDay ?? true;
+  const timeChanges = lib.getTimeChanges(true);
+  let newDay = application.options.restPrompted ? application.options.newDay : (simpleCalendarActive ? timeChanges.isNewDay : application.options.newDay ?? true);
   let promptNewDay = !simpleCalendarActive && workflow.restVariant !== "gritty" && application.options.promptNewDay;
 
   let usingDefaultSettings = CONSTANTS.USING_DEFAULT_LONG_REST_SETTINGS();

--- a/scripts/formapplications/prompt-rest/prompt-rest-shell.svelte
+++ b/scripts/formapplications/prompt-rest/prompt-rest-shell.svelte
@@ -90,11 +90,13 @@
       await game.time.advance(timeChanges.restTime);
     }
 
+    const trueNewDay = simpleCalendarActive ? timeChanges.isNewDay : forceNewDay;
+
     if (configuration.size) {
       SocketHandler.emit(SocketHandler.PROMPT_REST, {
         userActors: [...configuration],
         restType,
-        newDay: forceNewDay,
+        newDay: trueNewDay,
         promptNewDay: false
       })
     }

--- a/scripts/formapplications/short-rest/short-rest-shell.svelte
+++ b/scripts/formapplications/short-rest/short-rest-shell.svelte
@@ -43,7 +43,7 @@
 
   const simpleCalendarActive = lib.getSetting(CONSTANTS.SETTINGS.ENABLE_SIMPLE_CALENDAR_INTEGRATION);
   const timeChanges = lib.getTimeChanges(false);
-  let newDay = simpleCalendarActive ? timeChanges.isNewDay : application.options.newDay;
+  let newDay = application.options.restPrompted ? application.options.newDay : (simpleCalendarActive ? timeChanges.isNewDay : application.options.newDay ?? true);
   let promptNewDay = !simpleCalendarActive && workflow.restVariant !== "epic" && application.options.promptNewDay;
 
   updateHealthBarText();

--- a/scripts/sockets.js
+++ b/scripts/sockets.js
@@ -110,8 +110,12 @@ export default class SocketHandler {
     const offlineIndexOffset = offlineResters.length > 1 ? (offlineResters.length / 2) * -1 : 0;
 
     offlineResters.forEach((actor, index) => {
-      actor[data.restType](
-				{ options: { actorsToRest: allActorsResting.map(actor => actor.uuid) } },
+      actor[data.restType]({
+          newDay: data.newDay,
+          promptNewDay: data.promptNewDay,
+          restPrompted: true,
+          options: { actorsToRest: allActorsResting.map(actor => actor.uuid) } 
+        },
 	      offlineIndexOffset ? { left: offlineMidPoint + (offlineIndexOffset + index) * width } : {}
       );
     });


### PR DESCRIPTION
1. Long rest shell was checking new day based on short rest time change.
2. Rest prompt only cared about checkbox (which doesn't exist with Simple Calendar integration), now uses time changes in `submitPrompt()`.
3. With Simple Calendar enabled & time passing enabled, prompted rests would check the time change themselves AFTER time had passed, so if a new day passed already it would evaluate to false (and if a new day would pass with 2 such rests in a row, it would evaluate to true). Changed rest shells to check if a prompted rest and if so just use passed in value for `newDay`.

2 & 3 should resolve #185 